### PR TITLE
Error for failed user confirmation

### DIFF
--- a/apps/web/src/app/admin-console/common/base-members.component.ts
+++ b/apps/web/src/app/admin-console/common/base-members.component.ts
@@ -222,6 +222,11 @@ export abstract class BaseMembersComponent<UserView extends UserViewTypes> {
       }
       await confirmUser(publicKey);
     } catch (e) {
+      this.toastService.showToast({
+        variant: "error",
+        title: this.i18nService.t("errorAdminConfirmUser"),
+        message: e.message,
+      });
       this.logService.error(`Handled exception: ${e}`);
     }
   }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3832,6 +3832,9 @@
       }
     }
   },
+  "errorAdminConfirmUser": {
+    "message": "Failed to confirm user"
+  },
   "editedUserId": {
     "message": "Edited user $ID$.",
     "placeholders": {


### PR DESCRIPTION
This is not only for the SSO.
I believe when running with email disabled a user will be `confirmed` as soon as he is invited but if the account is not yet created the `confirm` will fail.