### PR TITLE
[SSO] Hide the Master password

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -20,8 +20,18 @@
         formControlName="email"
         bitInput
         appAutofocus
+        class="vw-email-continue"
         (input)="onEmailInput($event)"
         (keyup.enter)="continuePressed()"
+      />
+      <input
+        type="email"
+        formControlName="email"
+        bitInput
+        appAutofocus
+        class="vw-email-sso"
+        (input)="onEmailInput($event)"
+        (keyup.enter)="handleSsoClick()"
       />
     </bit-form-field>
 
@@ -37,9 +47,28 @@
     </bit-form-control>
 
     <div class="tw-grid tw-gap-3">
-      <!-- Continue button -->
-      <button type="button" bitButton block buttonType="primary" (click)="continuePressed()">
+      <!-- Continue button (sso is disabled) -->
+      <button
+        type="button"
+        bitButton
+        block
+        buttonType="primary"
+        class="vw-continue-login"
+        (click)="continuePressed()"
+      >
         {{ "continue" | i18n }}
+      </button>
+
+      <!-- SSO button -->
+      <button
+        type="button"
+        bitButton
+        block
+        buttonType="primary"
+        class="vw-sso-login"
+        (click)="handleSsoClick()"
+      >
+        {{ "useSingleSignOn" | i18n }}
       </button>
 
       <div class="tw-text-center vw-or-text">{{ "or" | i18n }}</div>
@@ -59,17 +88,16 @@
         </button>
       </ng-container>
 
-      <!-- Button to Login with SSO -->
+      <!-- Other button (sso enabled and password or device login is still available) -->
       <button
         type="button"
         bitButton
         block
         buttonType="secondary"
-        (click)="handleSsoClick()"
-        class="vw-sso-login"
+        class="vw-other-login"
+        (click)="continuePressed()"
       >
-        <i class="bwi bwi-provider tw-mr-1"></i>
-        {{ "useSingleSignOn" | i18n }}
+        {{ "other" | i18n }}
       </button>
     </div>
   </div>

--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -68,6 +68,7 @@
         class="vw-sso-login"
         (click)="handleSsoClick()"
       >
+        <i class="bwi bwi-provider tw-mr-1"></i>
         {{ "useSingleSignOn" | i18n }}
       </button>
 


### PR DESCRIPTION
With the new interface hiding the `Master password` login flow can't be done with a simple class because the `email` field will trigger it when pressing `enter`.

This modification change adjust the displayed button and primary/default action depending on `sso_enable` and `sso_only` settings (this requires a minor modification server side too).

I expect this might be too complex to merge but wanted some feedback.
