### PR TITLE
[SSO] Display sso login errors

### DIFF
--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -542,7 +542,7 @@ export class SsoComponent implements OnInit {
     await this.router.navigate(["lock"]);
   }
 
-  private async handleLoginError(e: unknown) {
+  private async handleLoginError(e: any) {
     this.logService.error(e);
 
     // TODO: Key Connector Service should pass this error message to the logout callback instead of displaying here
@@ -552,7 +552,15 @@ export class SsoComponent implements OnInit {
         title: "",
         message: this.i18nService.t("ssoKeyConnectorError"),
       });
+    } else {
+      this.toastService.showToast({
+        variant: "error",
+        title: null,
+        message: e.message,
+      });
     }
+    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+    await this.router.navigate(["/login"]);
   }
 
   private getOrgIdentifierFromState(state: string): string {


### PR DESCRIPTION
SSO login can fail due to a provider error or Vaultwarden might deny the login (email reused for example).
Without this change the user is left with a spinner and no information.

Note: this should have no impact for non SSO flow so could be merged whenever convenient.