### PR TITLE
[SSO] On sso redirection preserve subpath

### DIFF
--- a/apps/web/src/connectors/sso.ts
+++ b/apps/web/src/connectors/sso.ts
@@ -21,13 +21,14 @@ window.addEventListener("load", () => {
 });
 
 function initiateWebAppSso(code: string, state: string) {
+  const baseUrl = window.location.href.replace(/\/sso-connector.html.*$/, "");
   // If we've initiated SSO from somewhere other than the SSO component on the web app, the SSO component will add
   // a _returnUri to the state variable. Here we're extracting that URI and sending the user there instead of to the SSO component.
   const returnUri = extractFromRegex(state, "(?<=_returnUri=')(.*)(?=')");
   if (returnUri) {
-    window.location.href = window.location.origin + `/#${returnUri}`;
+    window.location.href = baseUrl + `/#${returnUri}`;
   } else {
-    window.location.href = window.location.origin + "/#/sso?code=" + code + "&state=" + state;
+    window.location.href = baseUrl + "/#/sso?code=" + code + "&state=" + state;
   }
 }
 


### PR DESCRIPTION
After the provider redirection we need to build a clean url, but we need to preserve the `subpath` if present. 

Note: this should have no impact for non SSO flow so could be merged whenever convenient.