### PR TITLE
Add css class to 2FA providers

### DIFF
--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup.component.html
+++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup.component.html
@@ -46,7 +46,10 @@
     {{ "twoStepLoginPolicyUserWarning" | i18n }}
   </bit-callout>
   <ul class="list-group list-group-2fa">
-    <li *ngFor="let p of providers" class="list-group-item d-flex align-items-center">
+    <li
+      *ngFor="let p of providers"
+      class="list-group-item d-flex align-items-center providers-2fa-{{ p.type }}"
+    >
       <div class="logo-2fa d-flex justify-content-center">
         <auth-two-factor-icon [provider]="p.type" [name]="p.name" />
       </div>


### PR DESCRIPTION
Add simple css class on 2FA providers to easily hide them without relying on `nth-child`.

Ex:  `app-two-factor-setup ul.list-group.list-group-2fa li.list-group-item:nth-child(1)` vs `li.providers-2fa-1`