### PR TITLE
move vaultwarden.css to body

### DIFF
--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -12,6 +12,19 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
     <link rel="manifest" href="manifest.json" />
+    <style>
+      @media (prefers-color-scheme: dark) {
+        html:not([lang]) .tw-text-muted {
+          color: rgb(136, 152, 181) !important;
+        }
+        html:not([lang]) body.layout_frontend {
+          background-color: rgb(18, 26, 39) !important;
+        }
+        html:not([lang]) img.new-logo-themed {
+          content: url("images/logo-white.svg") !important;
+        }
+      }
+    </style>
   </head>
   <body class="layout_frontend">
     <!-- webpackIgnore: true -->

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -12,19 +12,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
     <link rel="manifest" href="manifest.json" />
-    <style>
-      @media (prefers-color-scheme: dark) {
-        html:not([lang]) .tw-text-muted {
-          color: rgb(136, 152, 181) !important;
-        }
-        html:not([lang]) body.layout_frontend {
-          background-color: rgb(18, 26, 39) !important;
-        }
-        html:not([lang]) img.new-logo-themed {
-          content: url("images/logo-white.svg") !important;
-        }
-      }
-    </style>
   </head>
   <body class="layout_frontend">
     <!-- webpackIgnore: true -->

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -12,10 +12,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
     <link rel="manifest" href="manifest.json" />
-    <!-- webpackIgnore: true -->
-    <link rel="stylesheet" href="css/vaultwarden.css" />
   </head>
   <body class="layout_frontend">
+    <!-- webpackIgnore: true -->
+    <link rel="stylesheet" href="css/vaultwarden.css" />
     <app-root>
       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
       <div class="tw-p-8 tw-flex">


### PR DESCRIPTION
As reported in https://github.com/dani-garcia/vaultwarden/discussions/5980 webpack is adding the following chunks https://github.com/vaultwarden/vw_web_builds/blob/2aac8b6c6fdb62fb273076e629f7e0837ee29e91/apps/web/webpack.config.js#L104 after our https://github.com/vaultwarden/vw_web_builds/blob/2aac8b6c6fdb62fb273076e629f7e0837ee29e91/apps/web/src/index.html#L16 so overwriting the theme is currently not possible for every selector if something has been declared with `!important` because if the upstream styles.css is loaded later it will overrule our rules.
![image](https://github.com/user-attachments/assets/5f3525ec-51e1-41f1-b949-3d42e839595d)

Moving the line from the head to the `<body>` should fix that issue as far as I've tested it.