### PR TITLE
show error when not using secure context

### DIFF
--- a/libs/common/src/key-management/crypto/services/web-crypto-function.service.ts
+++ b/libs/common/src/key-management/crypto/services/web-crypto-function.service.ts
@@ -18,6 +18,28 @@ export class WebCryptoFunctionService implements CryptoFunctionService {
 
   constructor(globalContext: { crypto: Crypto }) {
     if (globalContext?.crypto?.subtle == null) {
+      const warningDiv = document.createElement("div");
+      warningDiv.setAttribute("role", "alert");
+      warningDiv.appendChild(
+        document.createTextNode(
+          "You are not using a secure context " +
+            "which is required for the Subtle Crypto API to work. ",
+        ),
+      );
+      const linkToWiki = document.createElement("a");
+      linkToWiki.appendChild(document.createTextNode("You need to enable HTTPS!"));
+      linkToWiki.href = "https://github.com/dani-garcia/vaultwarden/wiki/Enabling-HTTPS";
+      warningDiv.appendChild(linkToWiki);
+
+      const spinnerDiv = document.getElementsByClassName("spinner-container")[0];
+      spinnerDiv.setAttribute(
+        "class",
+        "toast-center-center tw-fixed tw-w-full tw-max-w-md tw-mx-auto " +
+          "tw-p-2 tw-ps-4 tw-text-main tw-bg-warning-100 " +
+          "tw-border-solid tw-border-2 tw-border-warning-700 tw-rounded-2xl",
+      );
+      spinnerDiv.replaceChild(warningDiv, spinnerDiv.firstChild);
+
       throw new Error(
         "Could not instantiate WebCryptoFunctionService. Could not locate Subtle crypto.",
       );


### PR DESCRIPTION
Continuing the conversation from https://github.com/dani-garcia/vaultwarden/discussions/6126#discussioncomment-13977575 I've come up with a way to replace the spinning icon with a styled error message that also links to the wiki:

https://github.com/user-attachments/assets/31c24f30-769d-43a7-9f9d-48388b491606