### PR TITLE
add custom class to hide password hint

### DIFF
--- a/libs/auth/src/angular/input-password/input-password.component.html
+++ b/libs/auth/src/angular/input-password/input-password.component.html
@@ -106,7 +106,7 @@
   </bit-form-field>
 
   <ng-container *ngIf="flow !== InputPasswordFlow.ChangePasswordDelegation">
-    <bit-form-field>
+    <bit-form-field class="vw-password-hint">
       <bit-label>{{ "masterPassHintLabel" | i18n }}</bit-label>
       <input
         id="input-password-form_new-password-hint"


### PR DESCRIPTION
as discussed in https://github.com/dani-garcia/vaultwarden/discussions/6719 this would make hiding the password hint easier if it has been disabled. I would merge this first in `v2025.12.2` and implement the server side changes once we have switched to using a new web-vault.