### PR TITLE
Skip email entry on login when SSO is the only auth method

### DIFF
--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -13,7 +13,7 @@
 <form [bitSubmit]="submit" [formGroup]="formGroup">
   <div [ngClass]="{ 'tw-hidden': loginUiState !== LoginUiState.EMAIL_ENTRY }">
     <!-- Email Address input -->
-    <bit-form-field>
+    <bit-form-field class="vw-email-form-field">
       <bit-label>{{ "emailAddress" | i18n }}</bit-label>
       <input
         type="email"
@@ -37,7 +37,7 @@
     </bit-form-field>
 
     <!-- Remember Email input -->
-    <bit-form-control>
+    <bit-form-control class="vw-remember-email">
       <input
         type="checkbox"
         formControlName="rememberEmail"

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -595,21 +595,24 @@ export class LoginComponent implements OnInit, OnDestroy {
    * @param event - The event object.
    */
   async handleSsoClick() {
-    // Make sure the email is valid
-    const isEmailValid = this.validateEmail();
-    if (!isEmailValid) {
-      return;
+    // Vaultwarden patch: when the email field is hidden (SSO_ONLY mode) the user has no
+    // way to provide an email and it is not actually needed by the server (single-tenant
+    // SSO uses FAKE_SSO_IDENTIFIER). Only validate when the user has typed something.
+    const email = this.formGroup.value.email ?? "";
+    if (email !== "") {
+      const isEmailValid = this.validateEmail();
+      if (!isEmailValid) {
+        return;
+      }
     }
 
-    // Make sure the email is not empty, for type safety
-    const email = this.formGroup.value.email;
-    if (!email) {
-      this.logService.error("Email is required for SSO");
-      return;
-    }
-
-    // Send the user to SSO, either through routing or through redirecting to the web app
-    await this.loginComponentService.redirectToSsoLogin(email);
+    // Vaultwarden has a single SSO configuration so the org identifier is always
+    // FAKE_SSO_IDENTIFIER. Pass it explicitly so the /sso component skips the
+    // "type your organization SSO identifier" prompt and proceeds to the IdP.
+    await this.loginComponentService.redirectToSsoLoginWithOrganizationSsoIdentifier(
+      email,
+      "00000000-01DC-01DC-01DC-000000000000",
+    );
   }
 
   /**


### PR DESCRIPTION
## Why
Today, with SSO_ONLY enabled, the login page still shows the email input field and the "Remember email" checkbox, and clicking the SSO button requires entering an email even though that email is ignored by the backend (single-tenant vaultwarden uses `FAKE_SSO_IDENTIFIER` server-side).

Two small changes were made in `libs/auth/src/angular/login/login.component.{html,ts}`:
- `class="vw-email-form-field"` on the `<bit-form-field>` wrapping the email inputs, and `class="vw-remember-email"` on the Remember-email `<bit-form-control>`. These hooks let the vaultwarden SCSS template hide both elements when `sso_only=true`.
- `handleSsoClick()` now tolerates an empty email: if the form has no email it skips validation and proceeds. Single-tenant vaultwarden does not require an email to start the SSO flow.

## Test done
- Built locally with `make full`. With `SSO_ENABLED=true SSO_ONLY=true` and the companion vaultwarden SCSS change, the login page shows only the "Continue with SSO" button.
<img width="1919" height="1042" alt="Screenshot 2026-05-01 163036" src="https://github.com/user-attachments/assets/ca7499b3-813a-4d91-b398-36bca84b13bf" />
