### PR TITLE
Dummy Identifier value to skip screen

### DIFF
--- a/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
+++ b/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts
@@ -261,6 +261,7 @@ export class SetInitialPasswordComponent implements OnInit {
           this.orgSsoIdentifier,
         );
         this.orgId = autoEnrollStatus.id;
+        this.orgSsoIdentifier = autoEnrollStatus.identifier;
         this.resetPasswordAutoEnroll = autoEnrollStatus.resetPasswordEnabled;
         this.masterPasswordPolicyOptions =
           await this.policyApiService.getMasterPasswordPolicyOptsForOrgUser(this.orgId);

--- a/libs/auth/src/angular/sso/sso.component.html
+++ b/libs/auth/src/angular/sso/sso.component.html
@@ -4,12 +4,15 @@
     {{ "loading" | i18n }}
   </div>
   <div *ngIf="!loggingIn">
-    <bit-form-field>
-      <bit-label>{{ "ssoIdentifier" | i18n }}</bit-label>
-      <input bitInput type="text" formControlName="identifier" appAutofocus />
-    </bit-form-field>
     <div class="tw-flex tw-gap-2">
-      <button type="submit" bitButton bitFormButton buttonType="primary" [block]="true">
+      <button
+        type="submit"
+        bitButton
+        bitFormButton
+        buttonType="primary"
+        [block]="true"
+        appAutofocus
+      >
         {{ "continue" | i18n }}
       </button>
     </div>

--- a/libs/auth/src/angular/sso/sso.component.ts
+++ b/libs/auth/src/angular/sso/sso.component.ts
@@ -639,6 +639,9 @@ export class SsoComponent implements OnInit {
     const storedIdentifier = await this.ssoLoginService.getOrganizationSsoIdentifier();
     if (storedIdentifier != null) {
       this.identifierFormControl.setValue(storedIdentifier);
+    } else {
+      // Lastly, set the dummy value
+      this.identifierFormControl.setValue("00000000-01DC-01DC-01DC-000000000000");
     }
   }
 }

--- a/libs/common/src/admin-console/models/response/organization-auto-enroll-status.response.ts
+++ b/libs/common/src/admin-console/models/response/organization-auto-enroll-status.response.ts
@@ -2,11 +2,13 @@ import { BaseResponse } from "../../../models/response/base.response";
 
 export class OrganizationAutoEnrollStatusResponse extends BaseResponse {
   id: string;
+  identifier: string;
   resetPasswordEnabled: boolean;
 
   constructor(response: any) {
     super(response);
     this.id = this.getResponseProperty("Id");
+    this.identifier = this.getResponseProperty("Identifier");
     this.resetPasswordEnabled = this.getResponseProperty("ResetPasswordEnabled");
   }
 }


### PR DESCRIPTION
With the recent change around `/organizations/domain/sso/verified` it now always return the hardcoded value.

I think it makes sense to set it in the client, this allows to use a cleaner `/#/sso` for those who prefer to skip the email prompt (logout still redirect to login form with email sadly). And if it needs to change again lessen the risks of someone using an outdated value.

If called with the hardcoded identifier  `auto-enroll-status` can return a different Organization.
I believe it does not cause issues but at the same time the value is later used [in](https://github.com/bitwarden/clients/blob/06da95f756321f349703457babc1736ad16ab9cd/libs/angular/src/auth/password-management/set-initial-password/set-initial-password.component.ts#L290)